### PR TITLE
Write script to automatically count triples

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	"scripts": {
 		"test": "mocha --recursive --parallel src/test",
 		"benchmarkAllSparqlQueries": "bash src/bin/benchmarking/benchmarkAllQueries.sh",
+		"countAllTriples": "node src/bin/all/countAllTriples.mjs -o data/stats",
 		"fetchAllSparqlQueryResults": "bash src/bin/all/fetchAllQueryResults.sh",
 		"getIguanaJarZip": "wget https://github.com/dice-group/IGUANA/releases/download/v3.3.0/iguana-3.3.0.zip -P src/benchmarking",
 		"lgdFetchReleases": "bash src/bin/linkedGeoData/fetchReleases.sh",

--- a/src/bin/all/countAllTriples.mjs
+++ b/src/bin/all/countAllTriples.mjs
@@ -1,0 +1,74 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+import { program } from 'commander';
+
+import { sparqlEndpoints } from '../../node_modules/config.mjs';
+import { querySparql } from 'queries/fetch.mjs';
+
+program.option(
+	'-o, --output-path <outputPath>',
+	'Path for output queries.txt file'
+);
+
+program.parse(process.argv);
+const options = program.opts();
+
+const outputDirPath = options.outputPath || '.';
+
+const getGraphNameQuery = `SELECT DISTINCT ?g
+WHERE {
+    GRAPH ?g { ?s ?p ?o . }
+}`;
+
+const main = async () => {
+	const response = await querySparql('neptune', getGraphNameQuery, {
+		format: 'json',
+		quiet: true,
+	});
+	const graphNameResults = JSON.parse(response.result);
+	const graphNames = unwrapResults(graphNameResults, 'g');
+	const tripleCountQueries = graphNames.map(graph => ({
+		name: graph,
+		query: `SELECT (COUNT(?s) as ?count) FROM <${graph}> WHERE { ?s ?p ?o . } LIMIT 10`,
+	}));
+	const endpointQueries = Object.entries(sparqlEndpoints).map(
+		([name, endpoint]) => ({
+			name,
+			endpoint,
+			queries: tripleCountQueries,
+		})
+	);
+	const results = await Promise.all(endpointQueries.map(countTriples));
+	await fs.writeFile(
+		path.join(outputDirPath, 'counts.json'),
+		JSON.stringify(results, null, 4)
+	);
+};
+
+const unwrapResults = (results, key) =>
+	results.results.bindings.map(binding => binding[key].value);
+
+const countTriples = async endpointObject => {
+	const countResponses = await Promise.all(
+		endpointObject.queries.map(queryObject => {
+			return querySparql(endpointObject.endpoint, queryObject.query, {
+				format: 'json',
+				message: `Counted ${queryObject.name} at ${endpointObject.name}`,
+			});
+		})
+	);
+
+	const counts = countResponses.map((res, i) => {
+		let count;
+		try {
+			count = parseInt(unwrapResults(JSON.parse(res.result), 'count')[0]);
+		} catch {
+			count = 'Error';
+		}
+		return { name: endpointObject.queries[i].name, count };
+	});
+	return { name: endpointObject.name, counts };
+};
+
+main();

--- a/src/node_modules/config.mjs
+++ b/src/node_modules/config.mjs
@@ -17,9 +17,12 @@ export const EC2ResultsDir = '/home/ubuntu/Data/ontologies/benchmarking/results'
 // be updated in src/benchmarking/config.yml
 export const VIRTUOSO_ENDPOINT =
 	'http://ec2-18-170-45-162.eu-west-2.compute.amazonaws.com:8890';
+export const NEPTUNE_ENDPOINT =
+	'http://ec2-18-170-45-162.eu-west-2.compute.amazonaws.com:3000';
 
 export const sparqlEndpoints = {
 	virtuoso: `${VIRTUOSO_ENDPOINT}/sparql`,
+	neptune: `${NEPTUNE_ENDPOINT}/sparql`
 };
 
 /* Tests */

--- a/src/node_modules/queries/fetch.mjs
+++ b/src/node_modules/queries/fetch.mjs
@@ -47,17 +47,23 @@ export const querySparql = async (endpoint, query, options = {}) => {
 	}
 
 	if (res.ok) {
-		const result = await res.text();
-		if (!options.quiet) {
+		if (options.message) {
+			console.log(options.message)
+		}
+		else if (!options.quiet) {
 			console.log('[+] Succesully fetched query');
 		}
+		const result = await res.text();
 		return {
 			isSuccessful: true,
 			query,
 			result,
 		}
 	} else {
-		if (!options.quiet) {
+		if (options.message) {
+			console.log(`Failure for: ${options.message}`)
+		}
+		else if (!options.quiet) {
 			console.error('[-] Failed to fetch query');
 		}
 		return {


### PR DESCRIPTION
This PR introduces code that automates the counting of triples. It
counts the number of triples per Database per Graph. For example,
Virtuoso/MeSH is one instance of a count, whereas Neptune/Mesh is a
separate count.

closes #35